### PR TITLE
Return errors.

### DIFF
--- a/include/esp_update.h
+++ b/include/esp_update.h
@@ -1,6 +1,8 @@
 #ifndef __ESP_UPDATE_H
 #define __ESP_UPDATE_H
 
-void esp_update(char update_server[], char application[], char current_version[]);
+#include <esp_err.h>
+
+esp_err_t esp_update(char update_server[], char application[], char current_version[]);
 
 #endif


### PR DESCRIPTION
In most cases you probably don't want to actually fail the boot process, but in case you do we can return the error codes.